### PR TITLE
Up the supported version of node to reflect use of http and https client APIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,5 @@
     "url": "http://github.com/moshen/node-googlemaps"
   },
   "devDependencies": { "vows" : "*" },
-  "engines": { "node": ">=0.1.104" }
+  "engines": { "node": ">=0.3.6" }
 }
-
-


### PR DESCRIPTION
I should have included this in the previous pull request. The https module used in the `places` method was [introduced in Node v0.3.6](http://nodejs.org/docs/v0.3.6/changelog.html).
