### PR TITLE
HTTP 'close' event

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -16,6 +16,18 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
 	makeRequest(path, true, returnObjectFromJSON(callback));
 }
 
+exports.placeDetails = function(referenceId, key, callback, sensor, lang) {
+	var args = { 
+		reference: referenceId,
+		key: key
+	}
+	if (lang) args.lang = lang;
+	args.sensor = sensor || 'false';
+	
+	var path = '/maps/api/place/details/json?' + qs.stringify(args);
+	makeRequest(path, true, returnObjectFromJSON(callback));
+}
+
 // http://code.google.com/apis/maps/documentation/geocoding/
 exports.geocode = function(address , callback , sensor , bounds , region , language){
 	var args = {


### PR DESCRIPTION
I had an issue where I was getting no response. After debugging I found that the HTTP/HTTPS event for 'close' was being raised - according to the docs this gets raised if the connection closes before the 'end' event could be raised. I just refactored the function for the 'end' event so that it could also be called for the 'close' event.
