### PR TITLE
Places text search

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -87,6 +87,28 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
   return makeRequest('/maps/api/place/search/json', args, true, returnObjectFromJSON(callback));
 };
 
+exports.textSearch = function(query, key, callback, sensor) {
+  
+  var args = {
+    query: query,
+    key: key
+  }
+  
+  if (typeof query !=="undefined" && query !== null) {
+    args.query = query;
+  }
+  
+  if (typeof key !=="undefined" && key !== null) {
+    args.key = key;
+  }
+  
+  if (typeof lat)
+  
+  args.sensor = sensor || 'false';
+  
+  return makeRequest('/maps/api/place/textsearch/json', args, true, returnObjectFromJSON(callback));
+}
+
 exports.placeDetails = function(referenceId, key, callback, sensor, lang) {
   var args = {
     reference: referenceId,


### PR DESCRIPTION
only takes required values, not extended to take all optional params

ex: 

var gm = require('googlemaps');
var util = require('util');
var locationData;

gm.textSearch(place, apiKey, function(err, data){
      locationData = data;
});