### PR TITLE
Support for "Application-specific Reports"

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -17,6 +17,7 @@ exports.setProxy = function(uri) {
 
 var _config = {
   'google-client-id': null,
+  'google-channel': null,
   'stagger-time': 200,
   'encode-polylines': true,
   'proxy': null,
@@ -454,6 +455,10 @@ function buildUrl(path, args) {
   if (config('google-client-id') && config('google-private-key')) {
     args.client = config('google-client-id');
     path = path + "?" + qs.stringify(args);
+
+    if (config('google-channel')) {
+      path += "&channel=" + config('google-channel');
+    }
 
     // Create signer object passing in the key, telling it the key is in base64 format
     var signer = crypto.createHmac('sha1', config('google-private-key'));


### PR DESCRIPTION
This PR adds support for ["Application-specific Reports"](https://developers.google.com/maps/documentation/business/guide#Channels) by allowing business users to set a channel.
