### PR TITLE
Added pagetoken parameter to places search API

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -51,7 +51,7 @@ exports.config = config = function(key, value) {
 };
 
 // http://code.google.com/apis/maps/documentation/places/
-exports.places = function(latlng, radius, key, callback, sensor, types, lang, name, rankby) {
+exports.places = function(latlng, radius, key, callback, sensor, types, lang, name, rankby, pagetoken) {
 
   var args = {
     location: latlng,
@@ -80,6 +80,10 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
 
   if (typeof name !== "undefined" && name !== null) {
     args.name = name;
+  }
+
+  if (typeof pagetoken !== "undefined" && pagetoken !== null) {
+    args.pagetoken = pagetoken;
   }
 
   args.sensor = sensor || 'false';


### PR DESCRIPTION
I want to be able to add paginated results to my application, but the API call is missing a `pagetoken` parameter.

See: https://developers.google.com/places/documentation/search

No BC breaks, very minimal change.
