### PR TITLE
Allow departure_time argument for directions.

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -128,7 +128,7 @@ exports.reverseGeocode = function(latlng, callback, sensor, language ) {
 };
 
 // http://code.google.com/apis/maps/documentation/distancematrix/
-exports.distance = function(origins, destinations, callback, sensor, mode, alternatives, avoid, units, language) {
+exports.distance = function(origins, destinations, callback, sensor, mode, alternatives, avoid, units, language, departure_time) {
   var args = {
     'origins': origins,
     'destinations': destinations
@@ -137,6 +137,7 @@ exports.distance = function(origins, destinations, callback, sensor, mode, alter
   if (avoid) args.avoid = avoid;
   if (units) args.units = units;
   if (language) args.language = language;
+  if (departure_time) args.departure_time = departure_time;
   args.sensor = sensor || 'false';
 
   var path = '/maps/api/distancematrix/json';


### PR DESCRIPTION
This just allows for the addition of departure_time argument. In the case of mode set to 'transit', if no departure_time is specified google returns an error. e.g.  http://maps.googleapis.com/maps/api/directions/json?origin=Brooklyn&destination=Queens&sensor=false&mode=transit returns

{
   "routes" : [],
   "status" : "INVALID_REQUEST"
}

Where as, http://maps.googleapis.com/maps/api/directions/json?origin=Brooklyn&destination=Queens&sensor=false&departure_time=1343605500&mode=transit returns a proper answer.
