### PR TITLE
escape single quotes in urls so we don't break signatures

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -453,7 +453,15 @@ function encodeSignedNumber(num) {
 function buildUrl(path, args) {
   if (config('google-client-id') && config('google-private-key')) {
     args.client = config('google-client-id');
-    path = path + "?" + qs.stringify(args);
+
+    var query = qs.stringify(args).split('');
+    for (var i = 0; i < query.length; ++i) {
+      // request will escape these which breaks the signature
+      if (query[i] === "'") query[i] = escape(query[i]);
+    }
+    query = query.join('');
+
+    path = path + "?" + query;
 
     // Create signer object passing in the key, telling it the key is in base64 format
     var signer = crypto.createHmac('sha1', config('google-private-key'));


### PR DESCRIPTION
fixes moshen/node-googlemaps#29

request was escaping single quotes when we passed them in, after we had already generated a signature with unescaped quotes. We just need to escape them ourselves.

The problem lies here: https://github.com/joyent/node/blob/7494c84fe6fa1127de5a9827119d9e389cbfb016/lib/url.js#L62, so it looks like single quotes are the only character affected by this bug.

![syzg30j](https://f.cloud.github.com/assets/678338/1082143/71713a7e-1583-11e3-890f-83157417cac9.gif)
