### PR TITLE
Added case-insentive support for the 'mode' argument in both directions() and distance()

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -133,7 +133,7 @@ exports.distance = function(origins, destinations, callback, sensor, mode, alter
     'origins': origins,
     'destinations': destinations
   };
-  if (mode) args.mode = mode;
+  if (mode) args.mode = mode.toLowerCase();
   if (avoid) args.avoid = avoid;
   if (units) args.units = units;
   if (language) args.language = language;
@@ -149,7 +149,7 @@ exports.directions = function(origin, destination, callback, sensor, mode, waypo
     'origin': origin,
     'destination': destination
   };
-  if (mode) args.mode = mode;
+  if (mode) args.mode = mode.toLowerCase();
   if (waypoints) args.waypoints = waypoints;
   if (alternatives) args.alternatives = alternatives;
   if (avoid) args.avoid = avoid;


### PR DESCRIPTION
This supports mode:UPPERCASE('WALKING',etc.) & mode:LOWERCASE('walking',etc.). 
Earlier, it was just supporting LOWERCASE('walking','bicycling',etc). I think this is necessary as it gives the developer a little bit of freedom and reduces confusion for starters(like me.. ) :)

Case: 
Use(argument)->Result(In the JSONresponse)
mode = 'WALKING'->"travel_mode":"DRIVING"
mode = 'walking'->"travel_mode":"WALKING"
