### PR TITLE
handle a console-key parameter #15

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -516,8 +516,16 @@ function buildUrl(path, args) {
 // If secure is true, uses https. Otherwise http is used.
 var makeRequest = function(path, args, secure, callback, encoding) {
   var maxlen = 2048;
+  var consoleKey = config('console-key');
 
-  var path = buildUrl(path, args);
+  if (consoleKey){
+    // google requires https when including an apiKey
+    secure = true;
+    args.key = consoleKey;
+  }
+
+  path = buildUrl(path, args);
+
   if (path.length > maxlen) {
     error = new Error("Request too long for google to handle (" + maxlen + " characters).");
     if (typeof callback === 'function') {


### PR DESCRIPTION
now i can be like

``` js
var gm = require('googlemaps');
gm.config('console-key', 'xj555');
```

and my urls will be like `https://google/api/...&key=xj555`

Additionally, it is necessary to use https when the key is included, so this forces https when there is a key.
