### PR TITLE
Added pagetoken args to Places, Updated URI

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -51,7 +51,7 @@ exports.config = config = function(key, value) {
 };
 
 // http://code.google.com/apis/maps/documentation/places/
-exports.places = function(latlng, radius, key, callback, sensor, types, lang, name, rankby) {
+exports.places = function(latlng, radius, key, callback, pagetoken, sensor, types, lang, name, rankby) {
 
   var args = {
     location: latlng,
@@ -70,6 +70,10 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
     args.radius = radius;
   }
 
+  if (typeof pagetoken !== "undefined" && pagetoken !== null) {
+    args.pagetoken = pagetoken;
+  }
+
   if (typeof types !== "undefined" && types !== null) {
     args.types = types;
   }
@@ -84,7 +88,7 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
 
   args.sensor = sensor || 'false';
 
-  return makeRequest('/maps/api/place/search/json', args, true, returnObjectFromJSON(callback));
+    return makeRequest('/maps/api/place/nearbysearch/json', args, true, returnObjectFromJSON(callback));
 };
 
 exports.placeDetails = function(referenceId, key, callback, sensor, lang) {
@@ -472,7 +476,7 @@ function buildUrl(path, args) {
     path += "&signature=" + signature;
     return path;
   } else {
-    return path + "?" + qs.stringify(args);
+    return path + "?" + qs.stringify(args).replace('%2B','+').replace('%2C',',');
   }
 }
 


### PR DESCRIPTION
exports.places has been updated with pagetoken args which is necessary
to get subsequent places as the initial request returns 20, pagetoken
must be passed to get additional places from a location.

Also updated the URI to the new Google places URI as documented here
https://developers.google.com/places/documentation/search, the lat/lon
arguments were also failing on the stringily command which was
converting the +, into ascii hex codes and passed to the created URI