### PR TITLE
Can put the encoded path on the request (no need for encode points)

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -298,7 +298,9 @@ exports.staticMap = function(center, zoom, size, callback, sensor ,
             new_path += '|' + points[k];
           }
         }
-      }
+      } else if (paths[i].enc) {
+        new_path += '|enc:' + paths[i].enc;
+	  }
       args.path[i] = new_path.replace(/^\|/, '');
     }
   }


### PR DESCRIPTION
This is importante because the direction API already return encoded path points