### PR TITLE
test connection refused error

### DIFF
--- a/test/errors-test.js
+++ b/test/errors-test.js
@@ -5,7 +5,7 @@ var vows = require('vows'),
 vows.describe('errors').addBatch({
   'No connection': {
     topic: function(options) {
-      gm.config('proxy', 'http://no-valid-proxy.com');
+      gm.config('proxy', 'http://127.0.0.1:49151');
       gm.geocode('Hamburg', this.callback);
 
       // reset the proxy
@@ -15,8 +15,8 @@ vows.describe('errors').addBatch({
       assert.isUndefined(result);
       assert.isObject(err);
     },
-    'returns the error code ENOTFOUND': function(err, result) {
-      assert.equal(err.code, 'ENOTFOUND');
+    'returns the error code ECONNREFUSED': function(err, result) {
+      assert.equal(err.code, 'ECONNREFUSED');
     }
   },
 


### PR DESCRIPTION
This is not a good way to test a network failure, but I reckon it is slightly better than the previous test,
since it relies on a localhost IP and reserved port.
A better test would require to inject a `request` mock into the library, but this requires the new library to accept such injection
