### PR TITLE
distance args: remove alternatives, add departure_time (for business clients)

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -133,7 +133,7 @@ exports.reverseGeocode = function(latlng, callback, sensor, language ) {
 };
 
 // http://code.google.com/apis/maps/documentation/distancematrix/
-exports.distance = function(origins, destinations, callback, sensor, mode, alternatives, avoid, units, language) {
+exports.distance = function(origins, destinations, callback, sensor, mode, avoid, units, language, departureTime) {
   var args = {
     'origins': origins,
     'destinations': destinations
@@ -142,6 +142,7 @@ exports.distance = function(origins, destinations, callback, sensor, mode, alter
   if (avoid) args.avoid = avoid;
   if (units) args.units = units;
   if (language) args.language = language;
+  if (departureTime) args.departure_time = departureTime;
   args.sensor = sensor || 'false';
 
   var path = '/maps/api/distancematrix/json';


### PR DESCRIPTION
I just found out that the distance method (for the Distance Matrix API) cannot accept a departureTime, which is useful for Google Maps API business client to get durations (with traffic taken into account) like we can already on the directions method