### PR TITLE
allows for method geocode to ingest an object

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -106,16 +106,20 @@ exports.placeDetails = function(referenceId, key, callback, sensor, lang) {
 
 // http://code.google.com/apis/maps/documentation/geocoding/
 exports.geocode = function(address, callback, sensor, bounds, region, language) {
-  var args = {
-    'address': address
-  };
-  if (bounds) args.bounds = bounds;
-  if (region) args.region = region;
-  if (language) args.language = language;
-  args.sensor = sensor || 'false';
 
+  var args = {};
+  if (typeof address === 'object') {
+    args = address;
+    args.sensor = args.sensor || 'false';
+  } else {
+    args.address = address;
+    if (bounds) args.bounds = bounds;
+    if (region) args.region = region;
+    if (language) args.language = language;
+    args.sensor = sensor || 'false';
+  }
+  
   var path = '/maps/api/geocode/json';
-
   return makeRequest(path, args, config('secure'), returnObjectFromJSON(callback));
 };
 


### PR DESCRIPTION
allows to call the geocode method as

```
gm.geocode({address: "444 Castro Street", region:"US", language:"EN"}, callback);
```

instead of 

```
gm.geocode("444 Castro Street", callback, false, null, "US", "EN");
```

why? two reasons:
- It's cleaner to call
- It allows for compatibility with [memoizeasync](https://www.npmjs.org/package/memoizeasync) which might save you several requests when geocoding the same places over and over again.