### PR TITLE
Replaces deprecated refence paremeter with new placeid & tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test/
 .travis.yml
+

--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -537,6 +537,8 @@ var makeRequest = function(path, args, secure, callback, encoding) {
   var options = {
     uri: (secure ? 'https' : 'http') + '://maps.googleapis.com' + path
   };
+  
+  console.log(options.uri);
 
   if (encoding) options.encoding = encoding;
   if (config('proxy')) options.proxy = config('proxy');

--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -538,8 +538,6 @@ var makeRequest = function(path, args, secure, callback, encoding) {
     uri: (secure ? 'https' : 'http') + '://maps.googleapis.com' + path
   };
 
-  console.log(options.uri);
-
   if (encoding) options.encoding = encoding;
   if (config('proxy')) options.proxy = config('proxy');
 

--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -538,6 +538,8 @@ var makeRequest = function(path, args, secure, callback, encoding) {
     uri: (secure ? 'https' : 'http') + '://maps.googleapis.com' + path
   };
 
+  console.log(options.uri);
+
   if (encoding) options.encoding = encoding;
   if (config('proxy')) options.proxy = config('proxy');
 

--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -92,9 +92,9 @@ exports.places = function(latlng, radius, key, callback, sensor, types, lang, na
   return makeRequest('/maps/api/place/search/json', args, true, returnObjectFromJSON(callback));
 };
 
-exports.placeDetails = function(referenceId, key, callback, sensor, lang) {
+exports.placeDetails = function(placeId, key, callback, sensor, lang) {
   var args = {
-    reference: referenceId,
+    placeid: placeId,
     key: key
   };
   if (lang) args.lang = lang;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "http://github.com/moshen/node-googlemaps"
   },
   "devDependencies": {
-    "vows": "*"
+    "vows": "*",
+    "node-env-file": "^0.1.7"
   },
   "engines": {
     "node": ">=0.3.6"

--- a/test/placedetails-test.js
+++ b/test/placedetails-test.js
@@ -1,0 +1,26 @@
+var vows = require('vows'),
+  assert = require('assert'),
+  env = require('node-env-file'),
+  gm = require('../lib/googlemaps');
+
+// bring in env variables
+try{
+  env('../.env');
+}catch(err){
+  console.log('Error: '+err);
+}
+
+vows.describe('placeDetails').addBatch({
+  'Simple Places Details request(ChIJrTLr-GyuEmsRBfy61i59si0)': {
+    topic: function(){
+      gm.placeDetails('ChIJrTLr-GyuEmsRBfy61i59si0', process.env.APIKEY, this.callback, null, null);
+    },
+    'returns as a valid request': function(err, result){
+      assert.ifError(err);
+      assert.equal(result.status, 'OK');
+    },
+    'returns expected name for given PlaceId': function(err, result){
+      assert.equal(result.result.name , 'Australian Cruise Group');
+    }
+  }
+}).export(module);


### PR DESCRIPTION
Was using this to get details on a Place from Google but realized that the `placeDetails` function was using the old `reference` parameter. You can take a look [here](https://developers.google.com/places/webservice/details#PlaceDetailsRequests) for confirmation. So I updated it to use the new `placeid` parameter where necessary.

Also added in a simple test for the `placeDetails` function seeing as how it didn't exist before. You will also notice an update to the .gitignore which is just ignoring my local env variables that hold my API key. Hope this helps!