### PR TITLE
address or components parameter is require to submit a geocode request

### DIFF
--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -28,8 +28,8 @@ module.exports = function(params, callback) {
 
   var args = _assignParams({}, params, ACCEPTED_PARAMS['geocode']);
 
-  if (args.address == null) {
-    return callback(new Error('params.address is required'));
+  if (!args.address && !args.components) {
+    return callback(new Error('params.address/params.components is required'));
   }
 
   return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['geocode'], args, _jsonParser(callback));

--- a/test/unit/geocodeTest.js
+++ b/test/unit/geocodeTest.js
@@ -73,9 +73,8 @@ describe('geocode', function() {
       checkCall();
     });
 
-    it('should not accept a call without params.address', function(done){
+    it('should not accept a call without params.address and params.components', function(done){
       var params = {
-        "components": "components=country:GB",
         "bounds":     "55,-1|54,1",
         "language":   "en",
         "region":     "uk"
@@ -84,11 +83,10 @@ describe('geocode', function() {
       gmAPI.geocode( params, function(err, results) {
         should.not.exist(results);
         should.exist(err);
-        err.message.should.equal('params.address is required');
+        err.message.should.equal('params.address/params.components is required');
         done();
       });
     });
-
   });
 
   describe('success', function() {


### PR DESCRIPTION
```
Required parameters in a geocoding request:

address — The street address that you want to geocode, in the format used by the national postal service of the country concerned. Additional address elements such as business names and unit, suite or floor numbers should be avoided. Please refer to the FAQ for additional guidance. 
     or 
components — A component filter for which you wish to obtain a geocode. See Component Filtering for more information. The components filter will also be accepted as an optional parameter if an address is provided.
```