### PR TITLE
Fix broken Google Maps API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ var result = gmAPI.streetView(params);
 
 ### Further examples
 
-Please refer to the code, [tests](http://github.com/moshen/node-googlemaps/tree/master/test/) and the [Google Maps API docs](http://code.google.com/apis/maps/documentation/webservices/index.html) for further usage information.
+Please refer to the code, [tests](http://github.com/moshen/node-googlemaps/tree/master/test/) and the [Google Maps API docs](https://developers.google.com/maps/documentation/javascript/) for further usage information.
 
 
 ### Contributions


### PR DESCRIPTION
I am changing this to point to the documentation for the Google Maps Javascript API Home (https://developers.google.com/maps/documentation/javascript/) Another option would be to point to the direct API reference (https://developers.google.com/maps/documentation/javascript/reference)