### PR TITLE
Enable pass-through of pre-encoded polyline points.

### DIFF
--- a/lib/utils/parsePaths.js
+++ b/lib/utils/parsePaths.js
@@ -34,9 +34,9 @@ module.exports = function(paths, encodePolylines) {
       }
     }
 
-    if (!Array.isArray(path.points)) {
-      throw new Error('Each path must have an array of points');
-    } else {
+    if (typeof path.points === 'string' && path.points.slice(0,4) === 'enc:') {
+      p.push(path['points']);
+    } else if (Array.isArray(path.points)) {
       if (encodePolylines === true) {
         p.push( 'enc:' + _encodePolyline(path['points']));
       } else {
@@ -44,6 +44,8 @@ module.exports = function(paths, encodePolylines) {
           p.push(point);
         });
       }
+    } else {
+      throw new Error('Each path must have an array of points or an encoded polyline');
     }
 
     return p.join('|');

--- a/test/unit/utils/parsePathsTest.js
+++ b/test/unit/utils/parsePathsTest.js
@@ -68,6 +68,18 @@ describe('parsePaths', function() {
       result.should.equal(output);
     });
 
+    it('should use a pre-encoded polyline', function() {
+      var input = [
+        {
+          points: 'enc:hf|eFol{sZm@pD|@bA',
+          color: '0x0000ff',
+          weight: 5
+        }
+      ];
+      var output = "weight:5|color:0x0000ff|enc:hf|eFol{sZm@pD|@bA";
+      var result = parsePaths(input);
+      result.should.equal(output);
+    });
   });
 
 });


### PR DESCRIPTION
If your path comes from the Directions service then it is already an
encoded polyline, no need to decode it.
