### PR TITLE
Enable multiple style parameters in query string.

### DIFF
--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -1,7 +1,7 @@
 /**
  * Node.js native modules
  */
-var qs     = require('querystring');
+var qs     = require('qs');
 var crypto = require('crypto');
 
 // TODO
@@ -11,6 +11,8 @@ var REQUEST_MAX_LENGTH = 2048;
 
 function _buildUrl(config, args, path) {
 
+  var qsConfig = { indices: false, arrayFormat: 'repeat' };
+
   if (config.google_client_id && config.google_private_key) {
     args.client = config.google_client_id;
 
@@ -18,7 +20,7 @@ function _buildUrl(config, args, path) {
     // is this the best way to clean the query string?
     // why does request break the signature with ' character if the signature is generated before request?
     // signature = signature.replace(/\+/g,'-').replace(/\//g,'_');
-    var query = qs.stringify(args).split('');
+    var query = qs.stringify(args, qsConfig).split('');
     for (var i = 0; i < query.length; ++i) {
       // request will escape these which breaks the signature
       if (query[i] === "'") query[i] = escape(query[i]);
@@ -36,7 +38,7 @@ function _buildUrl(config, args, path) {
     path += "&signature=" + signature;
     return path;
   } else {
-    return path + "?" + qs.stringify(args);
+    return path + "?" + qs.stringify(args, qsConfig);
   }
 
 }

--- a/lib/utils/parseStyles.js
+++ b/lib/utils/parseStyles.js
@@ -39,6 +39,6 @@ module.exports = function(styles) {
 
     return s.join('|');
 
-  }).join('|');
+  });
 
 }

--- a/lib/utils/parseStyles.js
+++ b/lib/utils/parseStyles.js
@@ -1,5 +1,5 @@
 /**
-Transfors an array of styles into a pipe separeted string
+Transforms an array of style objects into an array of pipe separated strings
 
 input = [
   {
@@ -8,10 +8,20 @@ input = [
     'rules': {
       'hue': '0x00ff00'
     }
+  },
+  {
+    'feature': 'landscape',
+    'element': 'all',
+    'rules': {
+      'visibility': 'off'
+    }
   }
 ]
 
-output = feature:road.local|element:all|hue:0x00ff00
+output = [
+  "feature:road|element:all|hue:0x00ff00",
+  "feature:landscape|element:all|visibility:off"
+]
 **/
 
 module.exports = function(styles) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "check-types": "~1.3.2",
+    "qs": "^4.0.0",
     "request": "~2.44.0",
     "waitress": ">=0.0.2"
   },

--- a/test/unit/utils/parseStylesTest.js
+++ b/test/unit/utils/parseStylesTest.js
@@ -45,10 +45,13 @@ describe('parseStyles', function() {
         }
       ];
 
-      var output = "feature:road|element:all|hue:0x00ff00|feature:landscape|element:all|visibility:off";
+      var output = [
+          "feature:road|element:all|hue:0x00ff00",
+          "feature:landscape|element:all|visibility:off"
+      ];
 
       var result = parseStyles(input);
-      result.should.equal(output);
+      result.should.eql(output);
     });
 
   });

--- a/test/unit/utils/parseStylesTest.js
+++ b/test/unit/utils/parseStylesTest.js
@@ -27,7 +27,7 @@ describe('parseStyles', function() {
 
   describe('success', function() {
 
-    it('should transform an array of styles into a string', function() {
+    it('should transform an array of styles into an array of strings', function() {
       var input = [
         {
           'feature': 'road',


### PR DESCRIPTION
This requires the 'qs' library which does more than the Node 'querystring'
enabling us to spread the style array out nicely.

Updated the test as well.