### PR TITLE
Add traffic_model to accepted params list

### DIFF
--- a/lib/config/constants.json
+++ b/lib/config/constants.json
@@ -49,7 +49,8 @@
       "language":       "string",
       "avoid":          "string",
       "units":          "string",
-      "departure_time": "date"
+      "departure_time": "date",
+      "traffic_model":  "string"
     },
     "directions": {
       "origin":         "string",
@@ -62,7 +63,8 @@
       "region":         "string",
       "units":          "string",
       "departure_time": "date",
-      "arrival_time":   "date"
+      "arrival_time":   "date",
+      "traffic_model":  "string"
     },
     "elevation": {
       "locations": "string",


### PR DESCRIPTION
This adds the traffic_model parameter to the list of accepted params to support the new traffic model feature in Google Maps distance and directions APIs that can be used to predict time in traffic based on historical averages.  The parameter traffic_model defaults to best_guess accepts the variables best_guess, pessimistic, and optimistic.  