### PR TITLE
License as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright © 2016 node-googlemaps Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "main": "lib/index",
   "description": "A simple way to query the Google Maps API from Node.js",
+  "license": "MIT",
   "author": {
     "name": "Colin Kennedy",
     "email": "moshen.colin@gmail.com",


### PR DESCRIPTION
Fix #95 - Open source license

When I pushed the first commits to this 5 odd years ago I didn't realize the importance of proper open source licensing.  If I had, I wouldn't be making this awkward request to node-googlemaps authors and committers to please approve licensing this library under the MIT open source license.

Thank you.

- [x] @fabriziomoscon 
- [x] @aredridel
- [x] @brandonwamboldt 
- [x] @chevett
- [x] @craigvl
- [x] @duncanm 
- [x] @evansiroky 
- [x] @evnm 
- [x] @grobot 
- [x] @JoshSmith 
- [x] @Marsup 
- [x] @aemkei 
- [ ] @Kodextor 
- [x] @spatical 
- [x] @onthestairs 
- [x] @regality 
- [x] @sayotuke 
- [x] @sugendran
