### PR TITLE
Isolating JSON parsing exception in jsonParse

### DIFF
--- a/lib/utils/jsonParser.js
+++ b/lib/utils/jsonParser.js
@@ -13,11 +13,15 @@ module.exports = function(callback) {
       return callback(err);
     }
 
+    var json;
+
     try {
-      callback(err, JSON.parse(jsonString));
+      json = JSON.parse(jsonString);
     } catch (e) {
       return callback(e);
     }
+
+    callback(err, json);
 
   };
 

--- a/test/unit/utils/jsonParseTest.js
+++ b/test/unit/utils/jsonParseTest.js
@@ -1,0 +1,82 @@
+var should = require('should');
+
+var jsonParser = require('../../../lib/utils/jsonParser');
+
+describe('jsonParser', function() {
+
+  describe('failures', function() {
+
+    var invalidCallbacks = [null, undefined, false, 0, NaN, '', {}, new Object, new Date]
+
+    invalidCallbacks.forEach(function(invalid) {
+      it('should return false upon receiving ' + invalid + ' as callback', function() {
+        (jsonParser(invalid).should.eql(false));
+      })
+    });
+
+    it('should return parent error', function() {
+
+      var parser = jsonParser(function(err, jsonObj) {
+        should.not.exist(jsonObj);
+        should.exist(err);
+        err.should.eql('test error');
+      });
+
+      parser('test error');
+
+    });
+
+    it('should fail to parse an invalid json string', function() {
+
+      var parser = jsonParser(function(err, jsonObj) {
+        should.not.exist(jsonObj);
+        should.exist(err);
+        err.message.should.equal('Unexpected token i');
+      });
+
+      parser(null, 'i am an invalid json string');
+    
+    });
+
+    it('should call the callback only once if an error is thrown in callback execution', function() {
+
+      var callbackCount = 0;
+
+      var parser = jsonParser(function(err, jsonObj) {
+        callbackCount += 1;
+        if(!err) {
+          var err = new Error('test error');
+          throw err;
+        }
+      });
+
+      try {
+        parser(null, '{"a":"b"}');
+      } catch(e) {
+        // do nothing
+      }
+
+      callbackCount.should.eql(1);
+
+    })
+
+  });
+
+  describe('success', function() {
+
+    it('should parse a valid json string', function() {
+
+      var parser = jsonParser(function(err, jsonObj) {
+        should.not.exist(err);
+        should.exist(jsonObj);
+        jsonObj.should.have.property('a');
+        jsonObj.a.should.eql('b');
+      });
+
+      parser(null, '{"a":"b"}');
+
+    })
+
+  });
+
+});


### PR DESCRIPTION
In previous code, the entire callback along with JSON parsing was
encapsulated with a try / catch block.  Thus any error that occurs
within the callback bubbles up to and is caught in this scope.

I added a unit test to specifically test for this in
`test\unit\utils\jsonParseTest.js` called `should call the callback only
once if an error is thrown in callback execution`.