### PR TITLE
Allow mocked google api for local development

### DIFF
--- a/lib/config/constants.json
+++ b/lib/config/constants.json
@@ -3,6 +3,7 @@
   "ACCEPTED_CONFIG_KEYS": {
     "encode_polylines":   "boolean",
     "google_client_id":   "string",
+    "google_api_url":     "string",
     "key":                "string",
     "proxy":              "string",
     "secure":             "boolean",

--- a/lib/config/getDefault.js
+++ b/lib/config/getDefault.js
@@ -6,6 +6,7 @@
   return {
     encode_polylines: true,
     google_client_id: null,
+    google_api_url: 'maps.googleapis.com',
     key:              null,
     proxy:            null,
     secure:           false,

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -68,7 +68,7 @@ module.exports = function(request, config, path, args, callback, encoding) {
   }
 
   var options = {
-    uri: (secure ? 'https' : 'http') + '://maps.googleapis.com' + path
+    uri: (secure ? 'https' : 'http') + '://' + config.google_api_url + path
   };
 
   if (encoding) options.encoding = encoding;

--- a/test/unit/constructorTest.js
+++ b/test/unit/constructorTest.js
@@ -32,7 +32,7 @@ describe('constructor', function() {
             should.exist( gmAPI.request );
             gmAPI.request.should.be.instanceof(Function);
           });
-        } 
+        }
       }
     );
 
@@ -49,6 +49,7 @@ describe('constructor', function() {
       var config = {
         key:                'xxxxxxxxxxxxxxxx',
         google_client_id:   'test-client-id',
+        google_api_url:     'localhost',
         stagger_time:       1000,
         encode_polylines:   false,
         secure:             true,
@@ -62,11 +63,12 @@ describe('constructor', function() {
 
       gmAPI.config.key.should.equal( config.key );
       gmAPI.config.google_client_id.should.equal( config.google_client_id );
+      gmAPI.config.google_api_url.should.equal( config.google_api_url );
       gmAPI.config.stagger_time.should.equal( config.stagger_time );
       gmAPI.config.encode_polylines.should.equal( config.encode_polylines );
       gmAPI.config.secure.should.equal( config.secure );
       gmAPI.config.proxy.should.equal( config.proxy );
-      
+
       should.exist( gmAPI.config.google_private_key );
 
     });


### PR DESCRIPTION
I've been using this in my own project for a while but I thought it was due a pull request.

I like to be able to develop locally and also not hammer the google API during tests, so this allows a simple override of the gmaps api url using config.