### PR TITLE
Added per request length to _makeRequest.

### DIFF
--- a/lib/config/constants.json
+++ b/lib/config/constants.json
@@ -113,6 +113,19 @@
 
   },
 
+  "MAX_REQUEST_LENGTHS": {
+    "directions":         2048,
+    "distance-matrix":    2048,
+    "elevation":          -1,
+    "geocode":            2048,
+    "place-details":      2048,
+    "place-search":       2048,
+    "place-autocomplete": 2048,
+    "static-map":         2048,
+    "timezone":           2048,
+    "street-view":        2048
+  },
+
   "GOOGLEMAPS_ENDPOINTS": {
     "directions":      "/maps/api/directions/json",
     "distance-matrix": "/maps/api/distancematrix/json",

--- a/lib/directions.js
+++ b/lib/directions.js
@@ -15,7 +15,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -51,6 +51,6 @@ module.exports = function(params, callback) {
 
   _travelUtils.convertTargetTimes(args);
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['directions'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['directions'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['directions']);
 
 };

--- a/lib/distance.js
+++ b/lib/distance.js
@@ -15,7 +15,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -51,6 +51,6 @@ module.exports = function(params, callback) {
 
   _travelUtils.convertTargetTimes(args);
   
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['distance-matrix'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['distance-matrix'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['distance-matrix']);
 
 };

--- a/lib/elevationFromLocations.js
+++ b/lib/elevationFromLocations.js
@@ -15,7 +15,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -41,6 +41,6 @@ module.exports = function(params, callback) {
     args.locations = 'enc:' + _encodePolyline(args.locations);
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['elevation'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['elevation'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['elevation']);
 
 };

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -14,7 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -32,6 +32,6 @@ module.exports = function(params, callback) {
     return callback(new Error('params.address/params.components is required'));
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['geocode'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['geocode'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['geocode']);
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ var _constants        = require('./config/constants');
 
 var ACCEPTED_CONFIG_KEYS = _constants.ACCEPTED_CONFIG_KEYS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 var api = {
   placeSearch:            require('./placeSearch'),
@@ -254,7 +255,7 @@ var _elevationFromPath = function(request, config, path, samples, callback, sens
 
   if (count === 1) {
 
-    _makeRequest(request, config, GOOGLEMAPS_ENDPOINTS['elevation'], args, _jsonParser(callback));
+    _makeRequest(request, config, GOOGLEMAPS_ENDPOINTS['elevation'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['elevation']);
 
   } else {
 

--- a/lib/placeAutocomplete.js
+++ b/lib/placeAutocomplete.js
@@ -14,7 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -36,6 +36,6 @@ module.exports = function(params, callback) {
     return callback(new Error('params.input is required'));
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-autocomplete'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-autocomplete'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['place-autocomplete']);
 
 };

--- a/lib/placeDetails.js
+++ b/lib/placeDetails.js
@@ -14,7 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -36,6 +36,6 @@ module.exports = function(params, callback) {
     return callback(new Error('params.placeid is required'));
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-details'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-details'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['place-details']);
 
 };

--- a/lib/placeSearch.js
+++ b/lib/placeSearch.js
@@ -14,6 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 var MAX_RADIUS = 50000;
 
@@ -83,5 +84,5 @@ module.exports = function(params, callback) {
     }
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-search'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['place-search'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['place-search']);
 };

--- a/lib/reverseGeocode.js
+++ b/lib/reverseGeocode.js
@@ -14,7 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -32,6 +32,6 @@ module.exports = function(params, callback) {
     return callback(new Error('params.latlng/params.place_id is required'));
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['geocode'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['geocode'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['geocode']);
 
 };

--- a/lib/staticMap.js
+++ b/lib/staticMap.js
@@ -17,7 +17,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 function _errorHandler(callback, error) {
   if (typeof callback === 'function') {
@@ -111,6 +111,6 @@ module.exports = function(params, callback) {
     }
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['static-map'], args, callback, 'binary');
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['static-map'], args, callback, MAX_REQUEST_LENGTHS['static-map'], 'binary');
 
 };

--- a/lib/streetView.js
+++ b/lib/streetView.js
@@ -14,6 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 function _errorHandler(callback, error) {
   if (typeof callback === 'function') {
@@ -69,6 +70,6 @@ module.exports = function(params, callback) {
     }
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['street-view'], args, callback, 'binary');
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['street-view'], args, callback, MAX_REQUEST_LENGTHS['street-view'], 'binary');
 
 };

--- a/lib/timezone.js
+++ b/lib/timezone.js
@@ -14,7 +14,7 @@ var _constants = require('./config/constants');
 
 var ACCEPTED_PARAMS      = _constants.ACCEPTED_PARAMS;
 var GOOGLEMAPS_ENDPOINTS = _constants.GOOGLEMAPS_ENDPOINTS;
-
+var MAX_REQUEST_LENGTHS  = _constants.MAX_REQUEST_LENGTHS;
 
 module.exports = function(params, callback) {
 
@@ -39,6 +39,6 @@ module.exports = function(params, callback) {
     return callback(new Error('params.timestamp is required'));
   }
 
-  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['timezone'], args, _jsonParser(callback));
+  return _makeRequest(this.request, this.config, GOOGLEMAPS_ENDPOINTS['timezone'], args, _jsonParser(callback), MAX_REQUEST_LENGTHS['timezone']);
 
 };

--- a/lib/utils/makeRequest.js
+++ b/lib/utils/makeRequest.js
@@ -4,11 +4,6 @@
 var qs     = require('qs');
 var crypto = require('crypto');
 
-// TODO
-// see if this limit needs to be bound to the specific API call, Ex.: distance has a limit of 2000
-var REQUEST_MAX_LENGTH = 2048;
-
-
 function _buildUrl(config, args, path) {
 
   var qsConfig = { indices: false, arrayFormat: 'repeat' };
@@ -51,7 +46,8 @@ function _buildUrl(config, args, path) {
 /**
  * Makes the request to Google Maps API.
  */
-module.exports = function(request, config, path, args, callback, encoding) {
+module.exports = function(request, config, path, args, callback, requestMaxLength, encoding) {
+  requestMaxLength = requestMaxLength || -1;
 
   var secure = config.secure;
 
@@ -63,8 +59,8 @@ module.exports = function(request, config, path, args, callback, encoding) {
 
   path = _buildUrl(config, args, path);
 
-  if (path.length > REQUEST_MAX_LENGTH) {
-    error = new Error('Request too long for google to handle (' + REQUEST_MAX_LENGTH + ' characters).');
+  if (requestMaxLength != -1 && path.length > requestMaxLength) {
+    error = new Error('Request too long for google to handle (' + requestMaxLength + ' characters).');
     if (typeof callback === 'function') {
       return callback(error);
     }


### PR DESCRIPTION
I've been testing "elevation" API and it seems that it doesn't have an URL length limit. At least I could successfully pass a 26k characters URL to it.

Not sure what the limits for other API calls are, but since they might be different this change is needed.
