### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "check-types": "~1.3.2",
     "qs": "^4.0.0",
-    "request": "~2.44.0",
+    "request": "~2.74.0",
     "waitress": ">=0.0.2"
   },
   "scripts": {


### PR DESCRIPTION
node-googlemaps currently has a vulnerable dependency, introducing 2 different types of known vulnerabilities.

[ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency and  [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
You can see [Snyk test report](https://snyk.io/test/github/moshen/node-googlemaps) of this project for details.

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, which uses the fixed `tough-cookie` version 2.3.1, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
