### PR TITLE
Support 'now' as a date

### DIFF
--- a/lib/utils/assignParams.js
+++ b/lib/utils/assignParams.js
@@ -30,7 +30,7 @@ var check = require('check-types');
 
       if (expectedType == 'date') {
 
-        if (check.date(newParams[ key ])) {
+        if (newParams[ key ] == 'now' || check.date(newParams[ key ])) {
           params[ key ] = newParams[ key ];
         }
 

--- a/lib/utils/travelUtils.js
+++ b/lib/utils/travelUtils.js
@@ -18,7 +18,7 @@ travelUtils.validateCommonArgs = function(args) {
       if (args.waypoints != null) {
         throw new Error('It is not possible to specify waypoints when params.mode = transit');
       }
-    } 
+    }
   }
 
   if (args.avoid != null) {
@@ -60,7 +60,7 @@ travelUtils.validateCommonArgs = function(args) {
 
 travelUtils.convertTargetTimes = function(args) {
   // convert departure_time in UNIX timestamp
-  if (args.departure_time != null) {
+  if (args.departure_time != null && args.departure_time != 'now') {
     args.departure_time = Math.floor( args.departure_time/1000 )
   }
 


### PR DESCRIPTION
Per https://developers.google.com/maps/documentation/distance-matrix/intro you can specify 'now
' as a departure_time