### PR TITLE
fixed multiple paths

### DIFF
--- a/lib/utils/parsePaths.js
+++ b/lib/utils/parsePaths.js
@@ -48,6 +48,6 @@ module.exports = function(paths, encodePolylines) {
 
     return p.join('|');
 
-  }).join('|');
+  });
 
 }


### PR DESCRIPTION
When parsing the path array each next path must be transformed to &path=
The first path is transformed correctly but each next path is not.
Removing the .join('|') will fix this bug.

See https://developers.google.com/maps/documentation/static-maps/intro#URL_Parameters
-> Feature Parameters -> path:

"path (optional) defines a single path of two or more connected points to overlay on the image at specified locations. This parameter takes a string of point definitions separated by the pipe character (|). You may supply additional paths by adding additional path parameters. Note that if you supply a path for a map, you do not need to specify the (normally required) center and zoom parameters. For more information, see Google Static Maps API Paths below."

-> "You may supply additional paths by adding additional path parameters." and so each URL parameter "path" has the following format:

 &path=